### PR TITLE
fix: keep selected locations when supplementing

### DIFF
--- a/pretab/core/selectors.py
+++ b/pretab/core/selectors.py
@@ -26,7 +26,7 @@ import numpy as np
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 
 from .exceptions import IncompatibleParamsError, OptionalDependencyError
-from .knots import quantile_knots
+from .knots import quantile_knots, select_knots
 
 Task = Literal["regression", "classification"]
 
@@ -148,13 +148,30 @@ class BaseLocationSelector(ABC):
         return spaced
 
     def _supplement(self, existing: list[float], x: np.ndarray, target_count: int) -> list[float]:
-        """Top up an under-filled location set with quantile locations."""
-        if target_count - len(existing) <= 0:
-            return existing
+        """Top up an under-filled location set with quantile locations.
 
-        quantile_candidates = quantile_knots(x, target_count)
-        all_locations = set(existing) | set(quantile_candidates.tolist())
-        return sorted(all_locations)[:target_count]
+        The locations already selected are always kept; only the shortfall is
+        filled, and the quantile candidates used to fill it are down-sampled by
+        even spacing so they stay spread across the range.
+
+        Merging both sets and truncating with ``sorted(...)[:target_count]``
+        instead always discarded the *largest* values. Since
+        :func:`~pretab.core.knots.quantile_knots` already returns
+        ``target_count`` candidates, the merged set always overflowed by exactly
+        ``len(existing)``, so the truncation reliably threw away the data-driven
+        locations the selector had just found whenever they sat above the median.
+        """
+        missing = target_count - len(existing)
+        if missing <= 0:
+            return sorted(existing)
+
+        current = set(existing)
+        candidates = np.asarray(
+            [c for c in quantile_knots(x, target_count).tolist() if c not in current]
+        )
+        if len(candidates) > missing:
+            candidates = select_knots(candidates, missing)
+        return sorted(current | set(candidates.tolist()))
 
 
 class CARTLocationSelector(BaseLocationSelector):

--- a/tests/test_location_selectors.py
+++ b/tests/test_location_selectors.py
@@ -79,6 +79,57 @@ def test_cart_handles_nan_rows(data):
     assert np.isfinite(locations).all()
 
 
+# --------------------------------------------------------------------------- #
+# Supplementing an under-filled set must not discard the selected locations.
+#
+# ``quantile_knots`` already returns ``target_count`` candidates, so merging and
+# truncating with ``sorted(...)[:target_count]`` always dropped the largest
+# entries -- i.e. the tree-selected locations whenever they sat above the median.
+# --------------------------------------------------------------------------- #
+def test_supplement_keeps_every_existing_location():
+    x = np.linspace(0, 10, 500).reshape(-1, 1)
+    selector = CARTLocationSelector()
+
+    supplemented = selector._supplement([9.5, 9.7], x, 5)
+
+    assert 9.5 in supplemented
+    assert 9.7 in supplemented
+    assert len(supplemented) == 5
+    assert supplemented == sorted(supplemented)
+
+
+def test_supplement_fills_only_the_shortfall():
+    x = np.linspace(0, 10, 500).reshape(-1, 1)
+    selector = CARTLocationSelector()
+    existing = [1.0, 2.0, 3.0]
+
+    supplemented = selector._supplement(list(existing), x, 6)
+
+    assert set(existing).issubset(supplemented)
+    assert len(supplemented) == 6
+
+
+def test_supplement_is_a_noop_when_already_full():
+    x = np.linspace(0, 10, 500).reshape(-1, 1)
+    selector = CARTLocationSelector()
+
+    assert selector._supplement([2.0, 4.0, 6.0], x, 3) == [2.0, 4.0, 6.0]
+
+
+def test_supplement_spreads_the_added_candidates():
+    # A single existing location must not cause the fill-ins to bunch at one end.
+    x = np.linspace(0, 10, 500).reshape(-1, 1)
+    selector = CARTLocationSelector()
+
+    supplemented = selector._supplement([5.0], x, 4)
+
+    assert 5.0 in supplemented
+    assert min(supplemented) < 4.0
+    assert max(supplemented) > 6.0
+
+
+
+
 def test_cart_matches_knot_adapter(data):
     X, y = data
     adapter = CARTKnotSelector(max_basis_functions=12, degree=3)


### PR DESCRIPTION
Fixes #18.

## Problem

When a target-aware selector returns fewer locations than `min_count`, `_supplement` tops
the set up with quantile candidates:

```python
quantile_candidates = quantile_knots(x, target_count)
all_locations = set(existing) | set(quantile_candidates.tolist())
return sorted(all_locations)[:target_count]
```

`quantile_knots` already returns `target_count` entries, so the union always overflows by
exactly `len(existing)` — and truncating a *sorted* list always removes the largest values.
The step meant to *add* to the selector's findings systematically deleted them instead,
whenever they sat above the median.

## Fix

Keep every existing location; fill only the shortfall. The quantile candidates used as
filler are down-sampled with `select_knots` (even spacing) rather than sliced, so the
additions stay spread across the range instead of bunching at the low end.

## Result

Isolating the call, with three tree-selected locations and a target of 6:

```
existing : [-0.995, -0.026,  0.969]
before   : [-0.995 -0.714 -0.429 -0.143 -0.026  0.143]   <- 2 of 3 kept, all output <= 0.143
after    : [-0.995 -0.714 -0.143 -0.026  0.714  0.969]   <- 3 of 3 kept, spans the range
```

End to end, a feature with few distinct values (so the tree places only three spaced splits
against a `min_count` of 6) now retains all three:

```python
rng = np.random.default_rng(0)
xs = rng.choice([0.0, 0.05, 9.5, 9.8], size=300)
ys = (xs > 5).astype(float) + 0.01 * rng.normal(size=300)
Preprocessor(numerical_method="ple", output_dim=7).fit(pd.DataFrame({"x": xs}), ys)
# thresholds: [-1. -0.995 -0.99 -0.026 0.969 1.]
```

## A correction to the issue

The second reproduction in #18's description did not actually reach `_supplement` — I
instrumented it and the method is never called for that input, so the bunching it showed has
a different cause. I have [commented on the issue](https://github.com/OpenTabular/PreTab/issues/18)
with that correction and a repro that does exercise the path. The first reproduction in the
issue was accurate.

## Tests

Four added to `tests/test_location_selectors.py`:

- `test_supplement_keeps_every_existing_location` — the reported case
- `test_supplement_fills_only_the_shortfall`
- `test_supplement_is_a_noop_when_already_full`
- `test_supplement_spreads_the_added_candidates` — guards the low-end bias specifically

Full suite: 484 passed, 9 xfailed. `ruff check` clean on both changed files; pyright
unchanged at its pre-existing 71 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
