### PR TITLE
fix(temporal): emit feature names in the order transform produces

### DIFF
--- a/pretab/transformers/temporal/cyclic.py
+++ b/pretab/transformers/temporal/cyclic.py
@@ -65,3 +65,21 @@ class CyclicalTimeTransformer(BasePreTabTransformer):
 
     def _output_sizes(self) -> list[int]:
         return [2] * self.n_features_in_
+
+    def get_feature_names_out(self, input_features=None):
+        """Return output names in the component-major order ``transform`` produces.
+
+        ``transform`` returns ``hstack([sin, cos])``, each an
+        ``(n_rows, n_features)`` block, so the columns run
+        ``sin_f0, sin_f1, cos_f0, cos_f1``. The inherited feature-major default
+        would label them the other way round. The ``cyclic{j}`` suffix scheme is
+        unchanged, so single-feature output is byte-identical; ``j`` is ``0`` for
+        the sine component and ``1`` for the cosine.
+        """
+        check_is_fitted(self, "n_features_in_")
+        if input_features is None:
+            input_features = [f"x{i}" for i in range(self.n_features_in_)]
+        return np.asarray(
+            [f"{feature}_cyclic{j}" for j in range(2) for feature in input_features],
+            dtype=object,
+        )

--- a/pretab/transformers/temporal/lag.py
+++ b/pretab/transformers/temporal/lag.py
@@ -63,3 +63,23 @@ class LagFeatureTransformer(BasePreTabTransformer):
 
     def _output_sizes(self) -> list[int]:
         return [self.n_lags] * self.n_features_in_
+
+    def get_feature_names_out(self, input_features=None):
+        """Return output names in the lag-major order ``transform`` produces.
+
+        ``transform`` hstacks one ``(n_rows, n_features)`` block per lag, so the
+        columns run ``lag1_f0, lag1_f1, ..., lag2_f0, ...``. The inherited
+        feature-major default would label them the other way round, mislabelling
+        every column but the first and last for multi-feature input.
+        """
+        check_is_fitted(self, "n_features_in_")
+        if input_features is None:
+            input_features = [f"x{i}" for i in range(self.n_features_in_)]
+        return np.asarray(
+            [
+                f"{feature}_lag{lag}"
+                for lag in range(self.n_lags)
+                for feature in input_features
+            ],
+            dtype=object,
+        )

--- a/pretab/transformers/temporal/rolling_stats.py
+++ b/pretab/transformers/temporal/rolling_stats.py
@@ -84,3 +84,24 @@ class RollingStatsTransformer(BasePreTabTransformer):
 
     def _output_sizes(self) -> list[int]:
         return [len(self.stats)] * self.n_features_in_
+
+    def get_feature_names_out(self, input_features=None):
+        """Return output names in the stat-major order ``transform`` produces.
+
+        ``transform`` hstacks one ``(n_rows, n_features)`` block per statistic,
+        so the columns run ``mean_f0, mean_f1, ..., std_f0, ...``. The inherited
+        feature-major default would label them the other way round. The
+        ``roll{j}`` suffix scheme is unchanged, so single-feature output is
+        byte-identical; ``j`` indexes ``self.stats``.
+        """
+        check_is_fitted(self, "n_features_in_")
+        if input_features is None:
+            input_features = [f"x{i}" for i in range(self.n_features_in_)]
+        return np.asarray(
+            [
+                f"{feature}_roll{j}"
+                for j in range(len(self.stats))
+                for feature in input_features
+            ],
+            dtype=object,
+        )

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -117,3 +117,73 @@ def test_cyclic_feature_names():
     np.testing.assert_array_equal(
         transformer.get_feature_names_out(["hour"]), ["hour_cyclic0", "hour_cyclic1"]
     )
+
+
+# --------------------------------------------------------------------------- #
+# Output names must line up with the columns ``transform`` actually produces.
+#
+# All three transformers hstack one (n_rows, n_features) block per lag / stat /
+# component, so the columns are block-major. The inherited default in
+# ``BasePreTabTransformer`` emits feature-major names, which mislabelled every
+# column but the first and last whenever there was more than one input feature.
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def two_features():
+    # B is always 100x A, so each column is identifiable from its value alone.
+    return np.column_stack([np.arange(8.0), np.arange(8.0) * 100])
+
+
+def test_lag_names_match_column_order(two_features):
+    transformer = LagFeatureTransformer(n_lags=2).fit(two_features)
+
+    names = list(transformer.get_feature_names_out(["A", "B"]))
+    assert names == ["A_lag0", "B_lag0", "A_lag1", "B_lag1"]
+
+    row = transformer.transform(two_features)[0]
+    # Column 1 holds B's lag-1 value (100), so it must be named for B.
+    assert row[1] == 100.0
+    assert names[1].startswith("B")
+
+
+def test_rolling_names_match_column_order(two_features):
+    transformer = RollingStatsTransformer(window_size=3, stats=("mean", "max")).fit(two_features)
+
+    names = list(transformer.get_feature_names_out(["A", "B"]))
+    assert names == ["A_roll0", "B_roll0", "A_roll1", "B_roll1"]
+
+    row = transformer.transform(two_features)[0]
+    assert row.tolist() == [1.0, 100.0, 2.0, 200.0]
+
+
+def test_cyclic_names_match_column_order():
+    X = np.column_stack([np.arange(8.0), np.arange(8.0)])
+    transformer = CyclicalTimeTransformer(period=8).fit(X)
+
+    names = list(transformer.get_feature_names_out(["A", "B"]))
+    assert names == ["A_cyclic0", "B_cyclic0", "A_cyclic1", "B_cyclic1"]
+
+    out = transformer.transform(X)
+    np.testing.assert_allclose(out[:, :2], np.sin(2 * np.pi * X / 8))
+    np.testing.assert_allclose(out[:, 2:], np.cos(2 * np.pi * X / 8))
+
+
+@pytest.mark.parametrize(
+    ("transformer", "expected"),
+    [
+        (LagFeatureTransformer(n_lags=2), ["x0_lag0", "x0_lag1"]),
+        (RollingStatsTransformer(window_size=3, stats=("mean",)), ["x0_roll0"]),
+        (CyclicalTimeTransformer(period=8), ["x0_cyclic0", "x0_cyclic1"]),
+    ],
+)
+def test_default_names_are_generated_for_single_feature(transformer, expected):
+    X = np.arange(8.0).reshape(-1, 1)
+    assert list(transformer.fit(X).get_feature_names_out()) == expected
+
+
+def test_names_count_matches_transform_width(two_features):
+    for transformer in (
+        LagFeatureTransformer(n_lags=3),
+        RollingStatsTransformer(window_size=3, stats=("mean", "std", "min")),
+    ):
+        transformer.fit(two_features)
+        assert len(transformer.get_feature_names_out()) == transformer.transform(two_features).shape[1]


### PR DESCRIPTION
Fixes #15.

## Problem

`LagFeatureTransformer`, `RollingStatsTransformer` and `CyclicalTimeTransformer` all build
their output by hstacking one `(n_rows, n_features)` block per lag / statistic / component,
so the columns are **block-major**. But they inherit
`BasePreTabTransformer.get_feature_names_out`, which walks
`zip(input_features, self._output_sizes())` and emits **feature-major** names.

For any input with more than one column, the labels are simply wrong:

```
Lag  names: ['A_lag0', 'A_lag1', 'B_lag0', 'B_lag1']
Lag  row 0: [  1. 100.   0.   0.]     # col 1 = 100 is B's lag-1, labelled A_lag1
Roll row 0: [  1. 100.   2. 200.]     # actual order mean_A, mean_B, max_A, max_B
```

Single-column input happens to be correct, which is why the existing tests pass.

## Fix

Override `get_feature_names_out` in each of the three classes to iterate blocks outermost,
matching the actual column layout.

## Scope note

I kept the existing `lag{j}` / `roll{j}` / `cyclic{j}` suffix scheme rather than renaming to
`_mean` / `_sin` / `_cos`. The issue suggested that rename as a bonus and it is genuinely
more informative — but it changes public output names for single-feature users whose labels
are correct today, which is a different kind of change from fixing a mislabelling. Keeping
the suffixes means:

- single-feature output is **byte-identical** (`['t_lag0', 't_lag1']` before and after);
- **no existing test needed changing**. My first pass did rename, and it broke three tests
  that encode the current scheme — a good signal it belongs in its own PR.

Happy to follow up with the rename if you want it.

## Result

```
Lag  ['A_lag0', 'B_lag0', 'A_lag1', 'B_lag1'] | row0 [  1. 100.   0.   0.]
Roll ['A_roll0', 'B_roll0', 'A_roll1', 'B_roll1'] | row0 [  1. 100.   2. 200.]
Cyc  ['A_cyclic0', 'B_cyclic0', 'A_cyclic1', 'B_cyclic1']
```

## Tests

Five added to `tests/test_temporal.py`, using a two-column fixture where `B = 100 * A` so
every column is identifiable from its value alone:

- one per transformer asserting names against the real column contents
- a parametrised check that default (`None`) names still work for single-feature input
- a width check that `len(get_feature_names_out()) == transform(X).shape[1]`

Full suite: 487 passed, 9 xfailed, no existing test modified. `ruff check` clean on changed
files; pyright unchanged at its pre-existing 71 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)