### PR TITLE
fix(splines): stop adding a collinear bias column to the B-spline basis

### DIFF
--- a/pretab/transformers/splines/base_spline.py
+++ b/pretab/transformers/splines/base_spline.py
@@ -123,7 +123,7 @@ class BaseSplineTransformer(BasePreTabTransformer):
     >>> from pretab.transformers import BSplineTransformer
     >>> X = np.linspace(0, 1, 50).reshape(-1, 1)
     >>> BSplineTransformer(output_dim=8).fit_transform(X).shape
-    (50, 9)
+    (50, 8)
     """
 
     def __init__(

--- a/pretab/transformers/splines/bspline.py
+++ b/pretab/transformers/splines/bspline.py
@@ -24,7 +24,15 @@ class BSplineTransformer(BaseSplineTransformer):
     is expanded column by column and the results are stacked horizontally.
 
     See :class:`~pretab.transformers.splines.base_spline.BaseSplineTransformer`
-    for the full parameter description. ``include_bias`` defaults to True here.
+    for the full parameter description.
+
+    .. note::
+       ``include_bias`` defaults to ``False``. A B-spline basis over a clamped
+       knot vector is a partition of unity -- every row sums to 1 -- so an
+       extra intercept column is an exact linear combination of the basis and
+       makes the design matrix singular. Set it to ``True`` only if a
+       downstream model needs the explicit column and tolerates the
+       collinearity.
 
     Examples
     --------
@@ -32,14 +40,14 @@ class BSplineTransformer(BaseSplineTransformer):
     >>> from pretab.transformers import BSplineTransformer
     >>> X = np.linspace(0, 1, 50).reshape(-1, 1)
     >>> BSplineTransformer(output_dim=8).fit_transform(X).shape
-    (50, 9)
+    (50, 8)
     """
 
     def __init__(
         self,
         output_dim=UNSET,
         degree: int = 3,
-        include_bias: bool = True,
+        include_bias: bool = False,
         knot_locations: np.ndarray | None = None,
         target_aware: bool = False,
         placement_strategy: str = "quantile",

--- a/tests/test_adaptive_output_dim.py
+++ b/tests/test_adaptive_output_dim.py
@@ -56,8 +56,7 @@ FIXED_WIDTH = {
     "tprs": OUTPUT_DIM,
     "mspline": OUTPUT_DIM,
     "ispline": OUTPUT_DIM,
-    # B-spline defaults to include_bias=True -> output_dim + 1
-    "bspline": OUTPUT_DIM + 1,
+    "bspline": OUTPUT_DIM,
 }
 
 # Families that honor the adaptive window when driven through the Preprocessor.

--- a/tests/test_spline_expansions.py
+++ b/tests/test_spline_expansions.py
@@ -132,3 +132,46 @@ def test_spline_penalty_matrix_symmetric(data):
     P = transformer.get_penalty_matrix()
     assert P.shape[0] == P.shape[1]
     assert np.allclose(P, P.T, atol=1e-9)
+
+
+# --------------------------------------------------------------------------- #
+# A partition-of-unity basis must not carry a redundant intercept column.
+#
+# ``BSplineTransformer`` used to default to ``include_bias=True``. A B-spline
+# basis over a clamped knot vector sums to 1 on every row, so the prepended
+# column of ones is an exact linear combination of the rest and the design
+# matrix is singular (condition number ~1e15).
+# --------------------------------------------------------------------------- #
+def test_bspline_default_design_is_full_rank():
+    X = np.linspace(0, 1, 200).reshape(-1, 1)
+
+    design = BSplineTransformer(output_dim=8).fit_transform(X)
+
+    assert design.shape[1] == 8
+    assert np.linalg.matrix_rank(design) == design.shape[1]
+    assert np.linalg.cond(design) < 1e6
+
+
+def test_bspline_basis_is_a_partition_of_unity():
+    # This is *why* the bias column is redundant; pin it so the reasoning holds.
+    X = np.linspace(0, 1, 200).reshape(-1, 1)
+
+    design = BSplineTransformer(output_dim=8).fit_transform(X)
+
+    np.testing.assert_allclose(design.sum(axis=1), 1.0)
+
+
+def test_bspline_include_bias_still_available_opt_in():
+    X = np.linspace(0, 1, 200).reshape(-1, 1)
+
+    design = BSplineTransformer(output_dim=8, include_bias=True).fit_transform(X)
+
+    assert design.shape[1] == 9
+    np.testing.assert_allclose(design[:, 0], 1.0)
+
+
+@pytest.mark.parametrize("cls", [BSplineTransformer, MSplineTransformer, ISplineTransformer])
+def test_bmi_splines_default_to_exactly_output_dim(cls):
+    X = np.linspace(0, 1, 200).reshape(-1, 1)
+
+    assert cls(output_dim=7).fit_transform(X).shape[1] == 7


### PR DESCRIPTION
Fixes #33.

## Problem

`BSplineTransformer` defaulted to `include_bias=True`, and it was the only spline family that
did. A B-spline basis over a clamped knot vector is a **partition of unity** — every row sums
to exactly 1 — so the prepended intercept column is an exact linear combination of the rest:

```
include_bias=True   (200, 9)  rank 8  cond 6.30e+15     <- singular
include_bias=False  (200, 8)  rank 8  cond 1.79e+01
```

`Preprocessor(numerical_method="bspline")` inherited that default, so this was the
out-of-the-box path, not an opt-in. Downstream, OLS has an unidentifiable intercept and a
regularized fit spends a coefficient on a direction that carries no information.

## Fix

Default `include_bias` to `False`, matching `MSplineTransformer`, `ISplineTransformer` and
`BaseSplineTransformer`. `include_bias=True` stays available for callers who want the column
and accept the collinearity, and the docstring now explains why it is off by default.

## One cause, three symptoms

The same change fixes two things filed alongside it in the issue:

| | before | after |
|---|---|---|
| `matrix_rank` / columns | 8 / 9 | 8 / 8 |
| `output_dims_` at `output_dim=7` | 8 (every other method: 7) | 7 |
| `output_dims_` at `adaptive`, `max_output_dim=9` | 10 | 9 |

The width mismatch mattered beyond aesthetics: `include_bias` is not a `Preprocessor`
parameter, so there was no way to opt out, and `max_output_dim` — which users set to bound
width — was silently exceeded.

## Tests

Four added to `tests/test_spline_expansions.py`:

- `test_bspline_default_design_is_full_rank` — rank and `cond < 1e6`; fails on the old default
- `test_bspline_basis_is_a_partition_of_unity` — pins *why* the bias column is redundant, so
  the reasoning is checked rather than just asserted in a comment
- `test_bspline_include_bias_still_available_opt_in`
- `test_bmi_splines_default_to_exactly_output_dim`, parametrised over B/M/I

## Changed existing expectations

`test_fixed_width_matches_expected[bspline]` pinned `OUTPUT_DIM + 1` with the comment
*"B-spline defaults to include_bias=True -> output_dim + 1"* — i.e. it encoded the asymmetry
being fixed. Updated to `OUTPUT_DIM`. Two docstring examples showing `(50, 9)` are now
`(50, 8)`.

**This changes a documented default.** I think it is right — the old default produces a
singular matrix, which is a defect rather than a preference — but it is a behaviour change,
so flagging it explicitly. If you would rather keep the default and only warn when
`include_bias=True` is requested on a partition-of-unity basis, say so and I will swap it.

Related, not changed here: `MSplineTransformer(include_bias=True)` is also rank-deficient
(M-splines are rescaled B-splines, so their span also contains the constants — `rank 8/9`).
That one is opt-in, so I left it alone; a warning would be a reasonable follow-up.
`ISplineTransformer(include_bias=True)` is full rank and unaffected.

Full suite: 486 passed, 9 xfailed; 24 doctests pass. `ruff check` clean on changed files;
pyright unchanged at its pre-existing 71 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)