### PR TITLE
fix(preprocessor): reject an unrecognized scaling value

### DIFF
--- a/pretab/pipeline/numerical.py
+++ b/pretab/pipeline/numerical.py
@@ -128,9 +128,18 @@ def get_numerical_transformer_steps(
         "minmax": ("minmax", MinMaxScaler(feature_range=(-1, 1))),
     }
 
-    # Add optional scaling step only if not already part of method
+    # Add optional scaling step only if not already part of method. An
+    # unrecognized name used to fall through the membership test below and
+    # silently produce an unscaled pipeline, so a typo disabled scaling instead
+    # of reporting it -- unlike ``method``, which is validated a few lines down.
     if scaling is not None:
         scaling = resolve_method(scaling, NUMERICAL_METHODS, NUMERICAL_ALIASES)
+        if scaling not in scalers and scaling != "none":
+            raise invalid_param_error(
+                "get_numerical_transformer_steps", "scaling", scaling,
+                "must name a scaler, or be None / 'none' to disable scaling",
+                valid={*scalers, "none"},
+            )
     if scaling in scalers and scaling != method:
         steps.append(scalers[scaling])
 

--- a/tests/test_method_aliases.py
+++ b/tests/test_method_aliases.py
@@ -3,6 +3,7 @@ import pandas as pd
 import pytest
 
 from pretab.core.exceptions import InvalidParamError
+from pretab.pipeline import get_numerical_transformer_steps
 from pretab.pipeline.registry import (
     CATEGORICAL_ALIASES,
     CATEGORICAL_METHODS,
@@ -144,3 +145,45 @@ def test_unknown_method_still_raises(sample_data):
     X, y = sample_data
     with pytest.raises(InvalidParamError):
         Preprocessor(numerical_method="definitely-not-a-method").fit_transform(X, y)
+
+
+# --------------------------------------------------------------------------- #
+# An unrecognized ``scaling`` value must raise, not silently disable scaling.
+#
+# ``resolve_method`` returns the input lowercased when it recognizes nothing, so
+# the membership test just failed and the pipeline came out unscaled -- unlike
+# ``method``, which is validated explicitly.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("scaling", ["not_a_scaler", "minmaxx", "standardisation"])
+def test_unknown_scaling_raises(scaling):
+    with pytest.raises(InvalidParamError, match="scaling"):
+        get_numerical_transformer_steps("ple", scaling=scaling)
+
+
+@pytest.mark.parametrize(
+    ("scaling", "expected"),
+    [
+        ("minmax", "minmax"),
+        ("MinMax", "minmax"),
+        ("min-max", "minmax"),
+        ("zscore", "scaler"),
+        ("standardization", "scaler"),
+    ],
+)
+def test_known_scaling_still_adds_its_step(scaling, expected):
+    steps = [name for name, _ in get_numerical_transformer_steps("ple", scaling=scaling)]
+    assert expected in steps
+
+
+@pytest.mark.parametrize("scaling", [None, "none", "passthrough"])
+def test_scaling_can_still_be_disabled(scaling):
+    steps = [name for name, _ in get_numerical_transformer_steps("ple", scaling=scaling)]
+    assert steps == ["imputer", "ple"]
+
+
+def test_unknown_scaling_raises_through_the_preprocessor():
+    rng = np.random.default_rng(0)
+    frame = pd.DataFrame({"a": rng.normal(size=50)})
+
+    with pytest.raises(InvalidParamError, match="scaling"):
+        Preprocessor(scaling="minmaxx").fit(frame, rng.normal(size=50))


### PR DESCRIPTION
Fixes #35.

## Problem

`resolve_method` returns its input lowercased when it recognizes nothing, so an unrecognized
`scaling` value fell through the membership test and produced a pipeline with **no scaler**:

```
'minmax'        -> ['imputer', 'minmax', 'ple']
'zscore'        -> ['imputer', 'scaler', 'ple']
'not_a_scaler'  -> ['imputer', 'ple']          <- silently unscaled
'minmaxx'       -> ['imputer', 'ple']          <- silently unscaled
```

`Preprocessor(scaling="minmaxx").fit(df, y)` completed without complaint. Meanwhile the same
typo in `numerical_method` raises, a few lines further down in the same function.

## Fix

Validate after alias resolution, keeping `None` and `"none"` as the documented ways to turn
scaling off:

```
InvalidParamError: get_numerical_transformer_steps.scaling = 'minmaxx' is invalid.
Constraint: must name a scaler, or be None / 'none' to disable scaling
Valid values: ['minmax', 'none', 'standardization']
```

Alias resolution is untouched, so `"MinMax"`, `"min-max"`, `"zscore"` and
`"standardization"` all keep working.

## Why it matters more than a typical typo guard

The failure is invisible. The fit succeeds, the output widths are identical, and only the
numeric scale of the features differs — so the mistake surfaces, if at all, as a quietly
worse model rather than an error.

## Tests

Nine added to `tests/test_method_aliases.py`: three unknown values that must raise, five
known spellings (including aliases) that must still insert their step, three disabling
spellings that must remain no-ops, and one end-to-end check through the `Preprocessor`.

Full suite: 492 passed, 9 xfailed. `ruff check` clean on changed files; pyright unchanged at
its pre-existing 71 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)