### PR TITLE
fix(preprocessor): raise a clear error on duplicate column names

### DIFF
--- a/pretab/preprocessor.py
+++ b/pretab/preprocessor.py
@@ -9,6 +9,7 @@ from sklearn.utils.validation import check_is_fitted
 
 from .core.exceptions import (
     IncompatibleParamsError,
+    PretabDataError,
     invalid_param_error,
 )
 from .core.logging import configure_logging, get_logger
@@ -284,6 +285,18 @@ class Preprocessor(TransformerMixin, BaseEstimator):
             X = pd.DataFrame(X)
         elif isinstance(X, np.ndarray):
             X = pd.DataFrame(X, columns=[f"feature_{i}" for i in range(X.shape[1])])
+
+        # ``X[col]`` returns a DataFrame rather than a Series for a duplicated
+        # label, so the dtype inspection below fails with an opaque
+        # ``AttributeError``. The ColumnTransformer this builds also keys its
+        # transformers by column name, so duplicates could not be routed even if
+        # detection coped with them.
+        duplicated = X.columns[X.columns.duplicated()].unique().tolist()
+        if duplicated:
+            raise PretabDataError(
+                f"Duplicate column names are not supported: {duplicated}.\n"
+                "Fix: rename the columns so every name is unique."
+            )
 
         for col in X.columns:
             num_unique_values = X[col].nunique()

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -249,3 +249,36 @@ def test_preprocessor_unknown_categorical_method():
     with pytest.raises(InvalidParamError) as exc:
         Preprocessor(categorical_method="bogus").fit(df, y)
     assert isinstance(exc.value, ValueError)
+
+
+# --------------------------------------------------------------------------- #
+# Duplicate column names must fail with a clear, actionable error.
+#
+# ``X[col]`` returns a DataFrame rather than a Series for a duplicated label, so
+# detection died on ``.dtype`` with an opaque AttributeError from pandas.
+# --------------------------------------------------------------------------- #
+def test_duplicate_column_names_raise_a_clear_error():
+    rng = np.random.default_rng(0)
+    frame = pd.DataFrame(np.column_stack([rng.normal(size=50)] * 2), columns=pd.Index(["a", "a"]))
+
+    with pytest.raises(PretabDataError, match=r"Duplicate column names are not supported: \['a'\]"):
+        Preprocessor(numerical_method="minmax").fit(frame, rng.normal(size=50))
+
+
+def test_duplicate_column_names_lists_every_offender():
+    rng = np.random.default_rng(0)
+    frame = pd.DataFrame(rng.normal(size=(50, 4)), columns=pd.Index(["a", "a", "b", "b"]))
+
+    with pytest.raises(PretabDataError) as excinfo:
+        Preprocessor(numerical_method="minmax").fit(frame, rng.normal(size=50))
+
+    assert "'a'" in str(excinfo.value) and "'b'" in str(excinfo.value)
+
+
+def test_unique_column_names_are_unaffected():
+    rng = np.random.default_rng(0)
+    frame = pd.DataFrame(rng.normal(size=(50, 2)), columns=pd.Index(["a", "b"]))
+
+    pre = Preprocessor(numerical_method="minmax").fit(frame, rng.normal(size=50))
+
+    assert sorted(pre.output_dims_) == ["a", "b"]


### PR DESCRIPTION
Fixes #37.

## Problem

```python
dup = pd.DataFrame(np.column_stack([rng.normal(size=50)] * 2), columns=["a", "a"])
Preprocessor(numerical_method="minmax").fit(dup, rng.normal(size=50))
```

```
AttributeError: 'DataFrame' object has no attribute 'dtype'
  ... pretab/preprocessor.py, line 307, in _detect_column_types
```

`X[col]` returns a **DataFrame** rather than a Series when `col` is duplicated, so the dtype
inspection has nothing to read. (`nunique()` on the preceding line happens to work on a
frame, which is why the failure surfaces one line later and looks unrelated.)

## Fix

Detect duplicates up front and raise a typed error naming them:

```
PretabDataError: Duplicate column names are not supported: ['a'].
Fix: rename the columns so every name is unique.
```

Rejecting rather than accommodating is the honest outcome here: the `ColumnTransformer` this
builds keys its transformers by column name (`f"num_{feature}"`), so duplicate labels could
not be routed unambiguously even if type detection coped with them.

## Tests

Three added to `tests/test_exceptions.py`: the reported single-duplicate case, a frame with
two distinct duplicated labels (asserting both are listed), and a unique-column frame to
confirm the check is not over-eager.

Full suite: 483 passed, 9 xfailed. `ruff check` clean on changed files; pyright unchanged at
its pre-existing 71 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)