### PR TITLE
fix(core): report output_dim, not min_output_dim, when it is too small

### DIFF
--- a/pretab/core/adaptive.py
+++ b/pretab/core/adaptive.py
@@ -88,9 +88,14 @@ class AdaptiveResolutionMixin:
 
         label = floor_label if floor_label is not None else str(floor)
         if lo < floor:
+            # ``lo`` is ``output_dim`` on the non-adaptive branch and whenever no
+            # explicit ``min_output_dim`` was supplied, so naming the parameter
+            # unconditionally pointed users at a knob they had not set -- and one
+            # that is ignored when ``adaptive`` is False.
+            name = "min_output_dim" if self.adaptive and min_req is not None else "output_dim"
             raise InvalidParamError(
-                f"min_output_dim must be >= {label}, got {lo}.\n"
-                "Fix: raise min_output_dim to at least the family minimum."
+                f"{name} must be >= {label}, got {lo}.\n"
+                f"Fix: raise {name} to at least the family minimum."
             )
         if ceil is not None and hi > ceil:
             raise InvalidParamError(

--- a/tests/test_adaptive_resolution.py
+++ b/tests/test_adaptive_resolution.py
@@ -254,3 +254,43 @@ def test_preprocessor_adaptive_rbf_within_window(frame):
     out = pre.fit_transform(X, y, return_array=True)
     assert isinstance(out, np.ndarray)
     assert 2 * 3 <= out.shape[1] <= 2 * 9
+
+
+# --------------------------------------------------------------------------- #
+# The floor error must name the parameter the caller actually set.
+#
+# ``lo`` is ``output_dim`` on the non-adaptive branch, but the message always
+# said "min_output_dim" -- a knob the user had not touched, and one that is
+# ignored entirely when ``adaptive`` is False.
+# --------------------------------------------------------------------------- #
+def test_floor_error_names_output_dim_when_not_adaptive():
+    from pretab.core.exceptions import InvalidParamError
+
+    rng = np.random.default_rng(0)
+    frame = pd.DataFrame({"a": rng.normal(size=50)})
+
+    with pytest.raises(InvalidParamError, match="output_dim must be >= 1, got 0"):
+        Preprocessor(numerical_method="ple", output_dim=0).fit(frame, rng.normal(size=50))
+
+
+def test_floor_error_does_not_mention_min_output_dim_when_not_adaptive():
+    from pretab.core.exceptions import InvalidParamError
+
+    rng = np.random.default_rng(0)
+    frame = pd.DataFrame({"a": rng.normal(size=50)})
+
+    with pytest.raises(InvalidParamError) as excinfo:
+        Preprocessor(numerical_method="ple", output_dim=0).fit(frame, rng.normal(size=50))
+
+    assert "min_output_dim" not in str(excinfo.value)
+
+
+def test_floor_error_names_min_output_dim_when_it_was_set():
+    from pretab.core.exceptions import InvalidParamError
+    from pretab.transformers import PLETransformer
+
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(50, 1))
+
+    with pytest.raises(InvalidParamError, match="min_output_dim must be >= 1"):
+        PLETransformer(output_dim=5, adaptive=True, min_output_dim=0).fit(X, rng.normal(size=50))


### PR DESCRIPTION
Fixes #38.

## Problem

`AdaptiveResolutionMixin._resolve_output_bounds` reported every floor violation against
`min_output_dim`, but `lo` is assigned `output_dim` on the non-adaptive branch a few lines
earlier. So a user who set `output_dim` got told about a parameter they never touched — and
one that is ignored entirely when `adaptive=False`:

```
Preprocessor(numerical_method="ple", output_dim=0)
-> min_output_dim must be >= 1, got 0.
   Fix: raise min_output_dim to at least the family minimum.
```

Acting on that "Fix:" line would not have helped.

The two halves of the package also disagreed: families that pre-validate `output_dim`
themselves reported it correctly, while those relying on the shared resolver did not.

```
ple          output_dim=0 -> min_output_dim must be >= 1, got 0.
cubicspline  output_dim=0 -> output_dim must be >= 3 for the cubic spline basis, got 0
```

## Fix

Pick the name from the branch that produced the value — `min_output_dim` only when
`adaptive` is set *and* the caller supplied one, otherwise `output_dim`. The "Fix:" line
follows suit.

```
ple                        output_dim=0     -> output_dim must be >= 1, got 0.
cubicspline                output_dim=0     -> output_dim must be >= 3 ...
adaptive, min_output_dim=0                  -> min_output_dim must be >= 1, got 0.
```

## Tests

Three added to `tests/test_exceptions.py`: the non-adaptive message names `output_dim`, it
does *not* mention `min_output_dim`, and the adaptive path still names `min_output_dim` when
that is genuinely what was set.

Cosmetic, but it is the first thing a user sees when they mis-size a transformer, and it was
pointing at the wrong knob.

Full suite: 483 passed, 9 xfailed. `ruff check` clean on changed files; pyright unchanged at
its pre-existing 71 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)